### PR TITLE
Match statefulset immutable errors by default

### DIFF
--- a/pkg/reconciler/resource.go
+++ b/pkg/reconciler/resource.go
@@ -203,7 +203,7 @@ func NewGenericReconciler(c client.Client, log logr.Logger, opts ReconcilerOpts)
 	}
 	if opts.RecreateErrorMessageSubstring == nil {
 		if opts.RecreateErrorMessageCondition == nil {
-			opts.RecreateErrorMessageCondition = MatchImmutableNoStatefulSet
+			opts.RecreateErrorMessageCondition = MatchImmutableErrorMessages
 		} else {
 			opts.RecreateErrorMessageSubstring = utils.StringPointer("immutable")
 		}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | related https://github.com/banzaicloud/logging-operator/issues/918
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Set RecreateErrorMessageCondition to MatchImmutableErrorMessages instead of MatchImmutableNoStatefulSet
so we're not excluding statefulset messages from the match.
 			
### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
Statefulset immutable errors should be detected.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->
This PR may be optional if https://github.com/banzaicloud/logging-operator/pull/941 is merged.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
