### PR TITLE
Add support for SecretSourceVolume

### DIFF
--- a/pkg/volume/volume_types.go
+++ b/pkg/volume/volume_types.go
@@ -40,6 +40,7 @@ type KubernetesVolume struct {
 	HostPathLegacy *corev1.HostPathVolumeSource `json:"host_path,omitempty"`
 	HostPath       *corev1.HostPathVolumeSource `json:"hostPath,omitempty"`
 	EmptyDir       *corev1.EmptyDirVolumeSource `json:"emptyDir,omitempty"`
+	SecretSource   *corev1.SecretVolumeSource   `json:"secret,omitempty"`
 	// PersistentVolumeClaim defines the Spec and the Source at the same time.
 	// The PVC will be created with the configured spec and the name defined in the source.
 	PersistentVolumeClaim *PersistentVolumeClaim `json:"pvc,omitempty"`
@@ -84,6 +85,11 @@ func (v *KubernetesVolume) GetVolume(name string) (corev1.Volume, error) {
 	} else if v.PersistentVolumeClaim != nil {
 		volume.VolumeSource = corev1.VolumeSource{
 			PersistentVolumeClaim: &v.PersistentVolumeClaim.PersistentVolumeSource,
+		}
+		return volume, nil
+	} else if v.SecretSource != nil {
+		volume.VolumeSource = corev1.VolumeSource{
+			Secret: v.SecretSource,
 		}
 		return volume, nil
 	}

--- a/pkg/volume/volume_types_test.go
+++ b/pkg/volume/volume_types_test.go
@@ -67,6 +67,29 @@ func TestKubernetesVolume_ApplyVolumeForPodSpec(t *testing.T) {
 	assert.Equal(t, "/here", spec.Containers[0].VolumeMounts[0].MountPath)
 }
 
+func TestSecretKubernetesVolume_ApplyVolumeForPodSpec(t *testing.T) {
+	vol := KubernetesVolume{
+		SecretSource: &v1.SecretVolumeSource{
+			SecretName: "secret",
+		},
+	}
+
+	spec := &v1.PodSpec{
+		Containers: []v1.Container{
+			{
+				Name: "test-container",
+			},
+		},
+	}
+
+	if err := vol.ApplyVolumeForPodSpec("vol", "test-container", "/here", spec); err != nil {
+		t.Fatalf("+%v", err)
+	}
+
+	assert.Equal(t, "vol", spec.Containers[0].VolumeMounts[0].Name)
+	assert.Equal(t, "/here", spec.Containers[0].VolumeMounts[0].MountPath)
+}
+
 func TestKubernetesVolume_ApplyPVCForStatefulSet(t *testing.T) {
 	vol := KubernetesVolume{
 		PersistentVolumeClaim: &PersistentVolumeClaim{

--- a/pkg/volume/zz_generated.deepcopy.go
+++ b/pkg/volume/zz_generated.deepcopy.go
@@ -41,6 +41,11 @@ func (in *KubernetesVolume) DeepCopyInto(out *KubernetesVolume) {
 		*out = new(v1.EmptyDirVolumeSource)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.SecretSource != nil {
+		in, out := &in.SecretSource, &out.SecretSource
+		*out = new(v1.SecretVolumeSource)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.PersistentVolumeClaim != nil {
 		in, out := &in.PersistentVolumeClaim, &out.PersistentVolumeClaim
 		*out = new(PersistentVolumeClaim)


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
Add support for SecretVolumeSource.

### Why?
Our use case is to mount AWS credentials from secret into fluentd statefulset managed by logging operator
